### PR TITLE
Improve pipeline blocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
 branches:
   only:
     - master
-    - schema-dev #ветка для изменения структуры репозитория/данных
 script:
   - yarn build
   - yarn merge-pr

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "test-watch": "jest --watch "
   },
   "dependencies": {
+    "@types/rimraf": "^2.0.3",
     "@types/uuid": "^3.4.5",
+    "rimraf": "^3.0.0",
     "simple-git": "^1.126.0",
     "source-map-support": "^0.5.13",
     "uuid": "^3.3.3"

--- a/scripts/create-block.js
+++ b/scripts/create-block.js
@@ -5,6 +5,7 @@ const blockFileName = process.argv[2];
 
 if (!blockFileName) {
   console.log('usage: node create-block.js <blockname>');
+  process.exit(0);
 }
 const blockFunctionName = blockFileName.split('-').reduce((result, current) => {
   if (!result) return current;

--- a/src/blocks/commitChanges.ts
+++ b/src/blocks/commitChanges.ts
@@ -1,19 +1,12 @@
 import { PullRequest, PipelineConfig } from '../types';
-const fs = require('fs');
 import sgit from 'simple-git/promise';
-
 export async function commitChanges(pullRequest: PullRequest, config: PipelineConfig) {
-  // if (process.env.TRAVIS_BRANCH) {
-  //   const git = sgit();
-  //   fs.unlinkSync(config.pullrequestsDir);
-  //   await git
-  //     .checkout(process.env.TRAVIS_BRANCH)
-  //     .then(() => git.add('.'))
-  //     .then(() => git.commit(`[skip-ci] Add ${pullRequest.en.meme.title}`))
-  //     .then(() =>
-  //       git.addRemote('new-origin', `https://${process.env.GITHUB_TOKEN}@github.com/${process.env.TRAVIS_REPO_SLUG}`),
-  //     )
-  //     .then(() => git.push('new-origin', process.env.TRAVIS_BRANCH));
-  // }
+  if (process.env.TRAVIS_BRANCH) {
+    const git = sgit();
+    await git
+      .checkout(process.env.TRAVIS_BRANCH)
+      .then(() => git.add('.'))
+      .then(() => git.commit(`[skip-ci] Add ${pullRequest[pullRequest.locales[0]].meme.title}`));
+  }
   return pullRequest;
 }

--- a/src/blocks/push-changes.ts
+++ b/src/blocks/push-changes.ts
@@ -1,0 +1,12 @@
+import { PullRequest, PipelineConfig } from '../types';
+import sgit from 'simple-git/promise';
+export async function pushChanges(pullRequest: PullRequest, config: PipelineConfig) {
+  if (process.env.TRAVIS_BRANCH) {
+    const git = sgit();
+    await git
+      .addRemote('new-origin', `https://${process.env.GITHUB_TOKEN}@github.com/${process.env.TRAVIS_REPO_SLUG}`)
+      .then(() => git.push('new-origin', process.env.TRAVIS_BRANCH))
+      .then(() => git.removeRemote('new-origin'));
+  }
+  return pullRequest;
+}

--- a/src/blocks/remove-pullrequests.ts
+++ b/src/blocks/remove-pullrequests.ts
@@ -1,0 +1,7 @@
+import { PullRequest, PipelineConfig } from '../types';
+import rimraf from 'rimraf';
+
+export async function removePullrequests(pullRequest: PullRequest, config: PipelineConfig) {
+  rimraf.sync(config.pullrequestsDir);
+  return pullRequest;
+}

--- a/src/pr-pipeline.ts
+++ b/src/pr-pipeline.ts
@@ -1,11 +1,10 @@
-import { createTags } from './blocks/createTags';
-import { PullRequest, PipelineConfig } from './types';
-import { createMeme } from './blocks/createMeme';
 import { addMemeToTags } from './blocks/addMemeToTags';
 import { commitChanges } from './blocks/commitChanges';
+import { createMeme } from './blocks/createMeme';
+import { createTags } from './blocks/createTags';
 import { getPullrequests } from './blocks/get-pullrequests';
 import { removePullrequests } from './blocks/remove-pullrequests';
-import { pushChanges } from './blocks/push-changes';
+import { PipelineConfig } from './types';
 
 export class PullRequestsPipeline {
   private blocks: Array<Function>;

--- a/src/pr-pipeline.ts
+++ b/src/pr-pipeline.ts
@@ -4,13 +4,15 @@ import { createMeme } from './blocks/createMeme';
 import { addMemeToTags } from './blocks/addMemeToTags';
 import { commitChanges } from './blocks/commitChanges';
 import { getPullrequests } from './blocks/get-pullrequests';
+import { removePullrequests } from './blocks/remove-pullrequests';
+import { pushChanges } from './blocks/push-changes';
 
 export class PullRequestsPipeline {
   private blocks: Array<Function>;
   private config: PipelineConfig;
   constructor(config: PipelineConfig) {
     this.config = config;
-    this.blocks = [createTags, createMeme, addMemeToTags, commitChanges];
+    this.blocks = [createTags, createMeme, addMemeToTags, removePullrequests, commitChanges];
   }
 
   async run(): Promise<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -337,6 +337,20 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/events@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
+  integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
+
+"@types/glob@*":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
+  integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
+  dependencies:
+    "@types/events" "*"
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -374,6 +388,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
+"@types/minimatch@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
+  integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
+
 "@types/node@*", "@types/node@^12.6.8":
   version "12.11.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.11.1.tgz#1fd7b821f798b7fa29f667a1be8f3442bb8922a3"
@@ -383,6 +402,14 @@
   version "1.18.3"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.18.3.tgz#64ff53329ce16139f17c3db9d3e0487199972cd8"
   integrity sha512-48rnerQdcZ26odp+HOvDGX8IcUkYOCuMc2BodWYTe956MqkHlOGAG4oFQ83cjZ0a4GAgj7mb4GUClxYd2Hlodg==
+
+"@types/rimraf@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-2.0.3.tgz#0199a46af106729ba14213fda7b981278d8c84f2"
+  integrity sha512-dZfyfL/u9l/oi984hEXdmAjX3JHry7TLWw43u1HQ8HhPv6KtfxnrZ3T/bleJ0GEvnk9t5sM7eePkgMqz3yBcGg==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
 
 "@types/source-map-support@^0.5.0":
   version "0.5.0"
@@ -3540,6 +3567,13 @@ rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.0.tgz#614176d4b3010b75e5c390eb0ee96f6dc0cebb9b"
+  integrity sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
   dependencies:
     glob "^7.1.3"
 


### PR DESCRIPTION
Fixes:
- `create-block` won't continue execution if block name isn't specified
Changes:
- Rollback to "vanilla" without any special backend frameworks
- Pipeline transformed to class for better internal decomposition
- `commitChanges` splitted into additional blocks: `remove-pullrequests` and `push-changes`
- Added `get-pullrequests` utility from `schema-dev` branch (for get all parsed pull-requests)
- Rethinked PR schema

P.S: I need to add the second pipeline just for push all commits together after all PR-s will processed