### PR TITLE
Sync pipeline per pullrequests

### DIFF
--- a/src/blocks/push-changes.ts
+++ b/src/blocks/push-changes.ts
@@ -1,12 +1,12 @@
 import { PullRequest, PipelineConfig } from '../types';
 import sgit from 'simple-git/promise';
-export async function pushChanges(pullRequest: PullRequest, config: PipelineConfig) {
+export async function pushChanges(): Promise<void> {
   if (process.env.TRAVIS_BRANCH) {
     const git = sgit();
-    await git
+    console.log('Pushing changes to remote...');
+    return git
       .addRemote('new-origin', `https://${process.env.GITHUB_TOKEN}@github.com/${process.env.TRAVIS_REPO_SLUG}`)
       .then(() => git.push('new-origin', process.env.TRAVIS_BRANCH))
       .then(() => git.removeRemote('new-origin'));
   }
-  return pullRequest;
 }

--- a/src/pr-pipeline.ts
+++ b/src/pr-pipeline.ts
@@ -4,7 +4,8 @@ import { createMeme } from './blocks/createMeme';
 import { createTags } from './blocks/createTags';
 import { getPullrequests } from './blocks/get-pullrequests';
 import { removePullrequests } from './blocks/remove-pullrequests';
-import { PipelineConfig } from './types';
+import { PipelineConfig, PullRequest } from './types';
+import { pushChanges } from './blocks/push-changes';
 
 export class PullRequestsPipeline {
   private blocks: Array<Function>;
@@ -15,11 +16,15 @@ export class PullRequestsPipeline {
   }
 
   async run(): Promise<void> {
-    getPullrequests(this.config.pullrequestsDir).map(async (pullRequest) => await this.processPullRequest(pullRequest));
+    for (const pullRequest of getPullrequests(this.config.pullrequestsDir)) {
+      await this.processPullRequest(pullRequest);
+    }
+    await pushChanges();
   }
-  async processPullRequest(pullRequest: any) {
+  async processPullRequest(pullRequest: PullRequest) {
     for (const block of this.blocks) {
       try {
+        console.log(`Apply ${block.name} at ${pullRequest[pullRequest.locales[0]].meme.title}`);
         pullRequest = await block(pullRequest, this.config);
       } catch (error) {
         console.error(`Pipeline block '${block.name}' failed with exception:`);


### PR DESCRIPTION
- Pipelines run unsynchronized because of Promise race. Fixed with `for..of`
- Added step for pushing changes (not tested yet, will run with this PR merge :) )